### PR TITLE
Todone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@
 
 | 年月日     | 内容                                                                                                                                                                      |
 | :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 2023.11.29 | [（登壇）](LACO Meet up #13『 私の〇〇挑戦記 LT大会 』) |
+| 2023.11.29 | （登壇）LACO Meet up #13『 私の〇〇挑戦記 LT大会 』 |
 | 2023.11.28 | [（登壇）第45回 Tokyo Jazug Night 40min session](https://www.youtube.com/live/T-FnzjIVQ1w?feature=shared&t=3912) |
 | 2023.10.28 | [（登壇）.NETラボ 勉強会 2023年10月](https://dotnetlab.connpass.com/event/296773/) |
 | 2023.10.11 | [（ハンズオン）Google製LLM「PaLM2」と対話できるLINE Botを爆速開発ハンズオン - YouTube](https://www.youtube.com/watch?v=RihQX1STpJg) |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@
 
 | 年月日     | 内容                                                                                                                                                                      |
 | :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2023.11.29 | [（登壇）](LACO Meet up #13『 私の〇〇挑戦記 LT大会 』) |
+| 2023.11.28 | [（登壇）第45回 Tokyo Jazug Night 40min session](https://www.youtube.com/live/T-FnzjIVQ1w?feature=shared&t=3912) |
 | 2023.10.28 | [（登壇）.NETラボ 勉強会 2023年10月](https://dotnetlab.connpass.com/event/296773/) |
 | 2023.10.11 | [（ハンズオン）Google製LLM「PaLM2」と対話できるLINE Botを爆速開発ハンズオン - YouTube](https://www.youtube.com/watch?v=RihQX1STpJg) |
 | 2023.09.22 | [（登壇）インフラエンジニアBooks#37 - 30分でわかる「AWSエンジニア入門講座」 - YouTube](https://www.youtube.com/live/xn7MtnnJ1f8?feature=shared&t=1231) |


### PR DESCRIPTION
# 更新履歴

## やったこと

### 第45回 Tokyo Jazug Night 40min session

2023.11.28に登壇した。- [登壇資料](https://speakerdeck.com/ymd65536/ge-ren-de-nizhu-mu-sitamicrosofttogithubnoatuhutetoqing-bao)

### LACO Meet up #13『 私の〇〇挑戦記 LT大会 』

2023.11.29に登壇した。スライド資料は後ほど
